### PR TITLE
Added a quick fix for Python versions below 3.9

### DIFF
--- a/hopfenmatrix/callbacks.py
+++ b/hopfenmatrix/callbacks.py
@@ -33,7 +33,7 @@ class CommandCallback:
     def __init__(
             self,
             command_callback: Callable,
-            accepted_aliases: Union[list[str], str],
+            accepted_aliases: Union[List[str], str],
             *,
             alias_is_regex: bool = False,
             make_default: bool = False,


### PR DESCRIPTION
Upon importing the `matrix` module, one with Python below version 3.9 would get a `TypeError`

Most "stable" distributions currently don't ship Python 3.9 yet (e.g. Debian 10 has 3.7, Fedora 32 has 3.8)